### PR TITLE
Update RedisSentinelManager::Resolve() signature to match Laravel 5.4 update on 17 April

### DIFF
--- a/src/RedisSentinelManager.php
+++ b/src/RedisSentinelManager.php
@@ -31,7 +31,7 @@ class RedisSentinelManager extends RedisManager
     /**
      * Get the Redis Connection instance represented by the specified name
      *
-     * @param string $name The name of the connection as defined in the
+     * @param string|null $name The name of the connection as defined in the
      * configuration
      *
      * @return \Illuminate\Redis\Connections\PredisConnection The configured

--- a/src/RedisSentinelManager.php
+++ b/src/RedisSentinelManager.php
@@ -42,7 +42,7 @@ class RedisSentinelManager extends RedisManager
      * @throws InvalidArgumentException If the specified connection is not
      * defined in the configuration
      */
-    protected function resolve($name)
+    public function resolve($name)
     {
         $options = Arr::get($this->config, 'options', [ ]);
 

--- a/src/RedisSentinelManager.php
+++ b/src/RedisSentinelManager.php
@@ -42,7 +42,7 @@ class RedisSentinelManager extends RedisManager
      * @throws InvalidArgumentException If the specified connection is not
      * defined in the configuration
      */
-    public function resolve($name)
+    public function resolve($name = null)
     {
         $options = Arr::get($this->config, 'options', [ ]);
 


### PR DESCRIPTION
https://github.com/laravel/framework/commit/d48cab89d5dff44037dac3ed55b9e32a50959cf1

I'm not sure if this will break backwards compatibility for older 5.4 versions?

Thanks.