### PR TITLE
Add PredisSentinelConnection that provides transaction implementation…

### DIFF
--- a/src/Connections/PredisSentinelConnection.php
+++ b/src/Connections/PredisSentinelConnection.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Monospice\LaravelRedisSentinel\Connections;
+
+use Illuminate\Redis\Connections\PredisConnection;
+
+class PredisSentinelConnection extends PredisConnection
+{
+    /**
+     * Execute commands in a transaction.  Avoids use of Predis transaction
+     * which does not support aggregate connections.  Mirrors implementation
+     * of PhpRedisConnection::transaction() in core Framework.
+     *
+     * @param  callable  $callback
+     * @return \Redis|array
+     */
+    public function transaction(callable $callback = null)
+    {
+        $transaction = $this->client()->multi();
+
+        return is_null($callback)
+            ? $transaction
+            : tap($this->client(), $callback)->exec();
+    }
+}

--- a/src/Connectors/PredisConnector.php
+++ b/src/Connectors/PredisConnector.php
@@ -2,8 +2,8 @@
 
 namespace Monospice\LaravelRedisSentinel\Connectors;
 
-use Illuminate\Redis\Connections\PredisConnection;
 use Illuminate\Support\Arr;
+use Monospice\LaravelRedisSentinel\Connections\PredisSentinelConnection;
 use Monospice\SpicyIdentifiers\DynamicMethod;
 use Predis\Client;
 
@@ -64,7 +64,7 @@ class PredisConnector
         // options array
         $clientOpts = array_diff_key($clientOpts, $sentinelKeys);
 
-        return new PredisConnection(
+        return new PredisSentinelConnection(
             $this->makePredisClient($server, $clientOpts, $sentinelOpts)
         );
     }


### PR DESCRIPTION
… that works w/aggregate connections.  Taylor was being pretty rigid in rejecting PR's that would remove the transaction from Horizon.  So, rather than attempt a framework PR that could see similar scrutiny, I thought I'd send this your way.  Essentially, this converts any transaction() invocation that current Predis can't handle into a MULTI / EXEC which Predis does handle.

This is modeled on the PhpRedisConnection::transaction() implementation (unchanged since 5.4).

I can't vouch for Lumen compatibility, but better chance of working than guaranteed exception!