### PR TITLE
Added autoboot configuration option and supporting implementation

### DIFF
--- a/config/redis-sentinel.php
+++ b/config/redis-sentinel.php
@@ -38,6 +38,7 @@ $port = env('REDIS_SENTINEL_PORT', env('REDIS_PORT', 26379));
 $password = env('REDIS_SENTINEL_PASSWORD', env('REDIS_PASSWORD', null));
 $database = env('REDIS_SENTINEL_DATABASE', env('REDIS_DATABASE', 0));
 $service = env('REDIS_SENTINEL_SERVICE', 'mymaster');
+$autoBoot = env('REDIS_SENTINEL_AUTO_BOOT', false);
 
 return [
 
@@ -69,6 +70,8 @@ return [
     'load_config' => true,
 
     'clean_config' => true,
+
+    'auto_boot' => $autoBoot,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Configuration/Loader.php
+++ b/src/Configuration/Loader.php
@@ -483,6 +483,9 @@ class Loader
         // the reference so that it can be garbage-collected:
         $this->packageConfig = null;
 
+        // We want to keep whether we should autoboot the provider
+        $autoBoot = $this->config->get('redis-sentinel.auto_boot', false);
+
         if ($this->config->get('redis-sentinel.clean_config', true) === true) {
             $this->config->set('redis-sentinel', [
                 'Config merged. Set redis-sentinel.clean_config=false to keep.',
@@ -491,5 +494,7 @@ class Loader
 
         // Skip loading package config when cached:
         $this->config->set('redis-sentinel.load_config', false);
+        // Make sure autoboot is retained.
+        $this->config->set('redis-sentinel.auto_boot', $autoBoot);
     }
 }

--- a/src/Configuration/Loader.php
+++ b/src/Configuration/Loader.php
@@ -483,18 +483,14 @@ class Loader
         // the reference so that it can be garbage-collected:
         $this->packageConfig = null;
 
-        // We want to keep whether we should autoboot the provider
-        $autoBoot = $this->config->get('redis-sentinel.auto_boot', false);
-
         if ($this->config->get('redis-sentinel.clean_config', true) === true) {
             $this->config->set('redis-sentinel', [
+                'auto_boot' => $this->config->get('redis-sentinel.auto_boot', false),
                 'Config merged. Set redis-sentinel.clean_config=false to keep.',
             ]);
         }
 
         // Skip loading package config when cached:
         $this->config->set('redis-sentinel.load_config', false);
-        // Make sure autoboot is retained.
-        $this->config->set('redis-sentinel.auto_boot', $autoBoot);
     }
 }

--- a/src/Configuration/Loader.php
+++ b/src/Configuration/Loader.php
@@ -122,6 +122,14 @@ class Loader
      */
     public $shouldIntegrateHorizon;
 
+
+    /**
+     * Indicates whether this should auto-boot the provider immediately.
+     *
+     * @var bool
+     */
+    public $shouldAutoBoot;
+
     /**
      * The current Laravel or Lumen application instance that provides context
      * and services used to load the appropriate configuration.
@@ -203,6 +211,8 @@ class Loader
 
         $this->shouldIntegrateHorizon = $this->horizonAvailable
             && $this->config->get('horizon.driver') === 'redis-sentinel';
+
+        $this->shouldAutoBoot = $this->config->get('redis-sentinel.auto_boot', false);
     }
 
     /**

--- a/src/RedisSentinelServiceProvider.php
+++ b/src/RedisSentinelServiceProvider.php
@@ -31,7 +31,7 @@ class RedisSentinelServiceProvider extends ServiceProvider
      *
      * @var boolean
      */
-    private $isBooted;
+    private $isBooted = false;
 
     /**
      * Loads the package's configuration and provides configuration values.

--- a/tests/Unit/Configuration/LoaderTest.php
+++ b/tests/Unit/Configuration/LoaderTest.php
@@ -537,6 +537,18 @@ class LoaderTest extends TestCase
         }
     }
 
+    public function testSetsAutoBootConfiguration()
+    {
+        // Test that it sets the boot value correctly
+        $this->config->set('redis-sentinel.auto_boot', false);
+        $this->loader->loadConfiguration();
+        $this->assertFalse($this->loader->shouldAutoBoot);
+
+        $this->config->set('redis-sentinel.auto_boot', true);
+        $this->loader->loadConfiguration();
+        $this->assertTrue($this->loader->shouldAutoBoot);
+    }
+
     public function testNormalizesSentinelConnectionHosts()
     {
         $this->startTestWithConfiguredApplication();

--- a/tests/Unit/RedisSentinelServiceProviderTest.php
+++ b/tests/Unit/RedisSentinelServiceProviderTest.php
@@ -200,10 +200,10 @@ class RedisSentinelServiceProviderTest extends TestCase
 
     public function testWaitsForBoot()
     {
-        $this->app->config->set('redis-sentinel.auto-boot', false);
+        $this->app->config->set('redis-sentinel.auto_boot', false);
         $this->provider->register();
 
-        $this->setExpectedException(InvalidArguementException::class);
+        $this->setExpectedException(\InvalidArgumentException::class);
 
         // It didn't auto boot
         $this->assertNull($this->app->cache->store('redis-sentinel'));
@@ -211,13 +211,10 @@ class RedisSentinelServiceProviderTest extends TestCase
 
     public function testAutoBoots()
     {
-        $this->app->config->set('redis-sentinel.auto-boot', true);
+        $this->app->config->set('redis-sentinel.auto_boot', true);
         $this->provider->register();
 
-        // It didn't auto boot
+        // Make sure it booted
         $this->assertNotNull($this->app->cache->store('redis-sentinel'));
-
-        $this->assertInstanceOf(RedisSentinelManager::class, $redisService);
-        $this->assertInstanceOf(RedisSentinelFactory::class, $redisService);
     }
 }

--- a/tests/Unit/RedisSentinelServiceProviderTest.php
+++ b/tests/Unit/RedisSentinelServiceProviderTest.php
@@ -198,14 +198,19 @@ class RedisSentinelServiceProviderTest extends TestCase
         }
     }
 
-    public function testAutoBootOption()
+    public function testWaitsForBoot()
     {
         $this->app->config->set('redis-sentinel.auto-boot', false);
         $this->provider->register();
 
+        $this->setExpectedException(InvalidArguementException::class);
+
         // It didn't auto boot
         $this->assertNull($this->app->cache->store('redis-sentinel'));
+    }
 
+    public function testAutoBoots()
+    {
         $this->app->config->set('redis-sentinel.auto-boot', true);
         $this->provider->register();
 

--- a/tests/Unit/RedisSentinelServiceProviderTest.php
+++ b/tests/Unit/RedisSentinelServiceProviderTest.php
@@ -197,4 +197,22 @@ class RedisSentinelServiceProviderTest extends TestCase
             $this->assertNotNull($this->app->session->driver('redis-sentinel'));
         }
     }
+
+    public function testAutoBootOption()
+    {
+        $this->app->config->set('redis-sentinel.auto-boot', false);
+        $this->provider->register();
+
+        // It didn't auto boot
+        $this->assertNull($this->app->cache->store('redis-sentinel'));
+
+        $this->app->config->set('redis-sentinel.auto-boot', true);
+        $this->provider->register();
+
+        // It didn't auto boot
+        $this->assertNotNull($this->app->cache->store('redis-sentinel'));
+
+        $this->assertInstanceOf(RedisSentinelManager::class, $redisService);
+        $this->assertInstanceOf(RedisSentinelFactory::class, $redisService);
+    }
 }


### PR DESCRIPTION
This is to address the issue in https://github.com/monospice/laravel-redis-sentinel-drivers/issues/17

UPDATE: Added ENV & config vars 'REDIS_SENTINEL_AUTO_BOOT' & 'auto_boot'
UPDATE: Configuration loader checks autoboot setting, provider will autoboot if this is set