### PR TITLE
Add Standalone option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1173,6 +1173,25 @@ Sentinel for something like a feed. For this setup, we'll configure multiple
 ],
 ```
 
+If you need a non-redis connection as well use the following syntax
+
+```
+'external_feed' => [
+
+            'options' => [
+                'host' => env('REDIS_SENTINEL_EXT', 'localhost'),
+                'password' => env('REDIS_SENTINEL_EXT_PASS', null),
+                'replication' => false,
+                'standalone' => true,
+                'port' => env('REDIS_SENTINEL_EXT_PORT', 6379),
+                'database' => env('REDIS_SENTINEL_EXT_DB', 1),
+                'read_write_timeout' => -1,
+            ]
+        ],
+
+```
+
+
 Notice that we removed the global `'options'` array and created a local
 `'options'` array for each connection. In this example setup, we store the
 application cache and sessions on one Redis server set, and feed data in

--- a/src/Manager/VersionedRedisSentinelManager.php
+++ b/src/Manager/VersionedRedisSentinelManager.php
@@ -2,6 +2,8 @@
 
 namespace Monospice\LaravelRedisSentinel\Manager;
 
+use Predis\Client;
+use Illuminate\Redis\Connections\PredisConnection;
 use Illuminate\Redis\RedisManager;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
@@ -40,6 +42,10 @@ abstract class VersionedRedisSentinelManager
     {
         $name = $name ?: 'default';
         $options = Arr::get($this->config, 'options', [ ]);
+        
+        if (isset($this->config[$name]['options']['standalone']) && $this->config[$name]['options']['standalone'] ) {
+            return new PredisConnection(new Client($this->config[$name]['options']));
+	    }
 
         if (isset($this->config[$name])) {
             return $this->connector()->connect($this->config[$name], $options);


### PR DESCRIPTION
There might be cases where a total overwrite of the redis connection is not working.

i.e. Session,Cache,Queue is handled internally with sentinel. However when there are i.e. external Queues using redis as well /wo sentinel. For those we need some option to get a non-redis connection from the manager