### PR TITLE
Implementing PhpRedis client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,35 +3,35 @@ dist: trusty
 sudo: false
 
 php:
-#   - 5.6
+  - 5.6
   - 7.0
-#   - 7.1
-#   - 7.2
-#   - 7.3
-#   - 7.4
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
 
 env:
-#   - LARAVEL_VERSION=">=5.4.0 <5.4.20"
-#   - LARAVEL_VERSION=">=5.4.20 <5.5.0"
-#   - LARAVEL_VERSION="5.5.*"
-#   - LARAVEL_VERSION="5.5.*" HORIZON=1
-#   - LARAVEL_VERSION="5.6.*"
-#   - LARAVEL_VERSION="5.6.*" HORIZON=1
-#   - LARAVEL_VERSION="5.7.*"
-#   - LARAVEL_VERSION="5.7.*" HORIZON=1
-#   - LARAVEL_VERSION="5.8.*"
-#   - LARAVEL_VERSION="5.8.*" HORIZON=1
+  - LARAVEL_VERSION=">=5.4.0 <5.4.20"
+  - LARAVEL_VERSION=">=5.4.20 <5.5.0"
+  - LARAVEL_VERSION="5.5.*"
+  - LARAVEL_VERSION="5.5.*" HORIZON=1
+  - LARAVEL_VERSION="5.6.*"
+  - LARAVEL_VERSION="5.6.*" HORIZON=1
+  - LARAVEL_VERSION="5.7.*"
+  - LARAVEL_VERSION="5.7.*" HORIZON=1
+  - LARAVEL_VERSION="5.8.*"
+  - LARAVEL_VERSION="5.8.*" HORIZON=1
   - LARAVEL_VERSION="6.*"
-#   - LARAVEL_VERSION="6.*" HORIZON=1
-#   - LARAVEL_VERSION="7.*"
-#   - LARAVEL_VERSION="7.*" HORIZON=1
-#   - LUMEN_VERSION="5.4.*"
-#   - LUMEN_VERSION="5.5.*"
-#   - LUMEN_VERSION="5.6.*"
-#   - LUMEN_VERSION="5.7.*"
-#   - LUMEN_VERSION="5.8.*"
-#   - LUMEN_VERSION="6.*"
-#   - LUMEN_VERSION="7.*"
+  - LARAVEL_VERSION="6.*" HORIZON=1
+  - LARAVEL_VERSION="7.*"
+  - LARAVEL_VERSION="7.*" HORIZON=1
+  - LUMEN_VERSION="5.4.*"
+  - LUMEN_VERSION="5.5.*"
+  - LUMEN_VERSION="5.6.*"
+  - LUMEN_VERSION="5.7.*"
+  - LUMEN_VERSION="5.8.*"
+  - LUMEN_VERSION="6.*"
+  - LUMEN_VERSION="7.*"
 
 matrix:
   exclude:
@@ -126,8 +126,6 @@ before_install:
   - if [ -n "$LUMEN_VERSION" ]; then composer require --no-update "laravel/lumen-framework:$LUMEN_VERSION"; fi
   - if [ -z "$HORIZON" ]; then composer remove --dev --no-update "laravel/horizon"; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then printf "\n" | pecl install -f redis; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then phpenv config-rm xdebug.ini; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
 
 install: travis_retry composer install --prefer-dist --no-interaction --no-suggest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ before_install:
 install: travis_retry composer install --prefer-dist --no-interaction --no-suggest
 
 before_script:
-  - sudo pecl install redis
+  - pecl install redis
   - echo "extension=redis.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
   - SUPERVISE=no travis_retry ./start-cluster.sh || { cat ./cluster/*.log; false; }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,6 @@ before_install:
 
 install: travis_retry composer install --prefer-dist --no-interaction --no-suggest
 
-before_script:
-  - SUPERVISE=no travis_retry ./start-cluster.sh || { cat ./cluster/*.log; false; }
+before_script: SUPERVISE=no travis_retry ./start-cluster.sh || { cat ./cluster/*.log; false; }
 
 script: vendor/bin/phpunit --exclude-group ${LUMEN_VERSION:+laravel-only},${HORIZON:-horizon}

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,8 +129,16 @@ before_install:
 install: travis_retry composer install --prefer-dist --no-interaction --no-suggest
 
 before_script:
-  - pecl install redis
-  - echo "extension=redis.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then printf "yes\n" | pecl install redis; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then printf "yes\n" | pecl install redis; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then printf "yes\n" | pecl install redis; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]]; then printf "yes\n" | pecl install redis; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.4" ]]; then printf "yes\n" | pecl install redis; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then echo "extension=redis.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"; fi`
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then echo "extension=redis.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"; fi`
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then echo "extension=redis.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"; fi`
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]]; then echo "extension=redis.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"; fi`
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.4" ]]; then echo "extension=redis.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"; fi`
   - SUPERVISE=no travis_retry ./start-cluster.sh || { cat ./cluster/*.log; false; }
 
 script: vendor/bin/phpunit --exclude-group ${LUMEN_VERSION:+laravel-only},${HORIZON:-horizon}

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,6 +128,9 @@ before_install:
 
 install: travis_retry composer install --prefer-dist --no-interaction --no-suggest
 
-before_script: SUPERVISE=no travis_retry ./start-cluster.sh || { cat ./cluster/*.log; false; }
+before_script:
+  - sudo pecl install redis
+  - echo "extension=redis.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
+  - SUPERVISE=no travis_retry ./start-cluster.sh || { cat ./cluster/*.log; false; }
 
 script: vendor/bin/phpunit --exclude-group ${LUMEN_VERSION:+laravel-only},${HORIZON:-horizon}

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,35 +3,35 @@ dist: trusty
 sudo: false
 
 php:
-  - 5.6
+#   - 5.6
   - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
-  - 7.4
+#   - 7.1
+#   - 7.2
+#   - 7.3
+#   - 7.4
 
 env:
-  - LARAVEL_VERSION=">=5.4.0 <5.4.20"
-  - LARAVEL_VERSION=">=5.4.20 <5.5.0"
-  - LARAVEL_VERSION="5.5.*"
-  - LARAVEL_VERSION="5.5.*" HORIZON=1
-  - LARAVEL_VERSION="5.6.*"
-  - LARAVEL_VERSION="5.6.*" HORIZON=1
-  - LARAVEL_VERSION="5.7.*"
-  - LARAVEL_VERSION="5.7.*" HORIZON=1
-  - LARAVEL_VERSION="5.8.*"
-  - LARAVEL_VERSION="5.8.*" HORIZON=1
+#   - LARAVEL_VERSION=">=5.4.0 <5.4.20"
+#   - LARAVEL_VERSION=">=5.4.20 <5.5.0"
+#   - LARAVEL_VERSION="5.5.*"
+#   - LARAVEL_VERSION="5.5.*" HORIZON=1
+#   - LARAVEL_VERSION="5.6.*"
+#   - LARAVEL_VERSION="5.6.*" HORIZON=1
+#   - LARAVEL_VERSION="5.7.*"
+#   - LARAVEL_VERSION="5.7.*" HORIZON=1
+#   - LARAVEL_VERSION="5.8.*"
+#   - LARAVEL_VERSION="5.8.*" HORIZON=1
   - LARAVEL_VERSION="6.*"
-  - LARAVEL_VERSION="6.*" HORIZON=1
-  - LARAVEL_VERSION="7.*"
-  - LARAVEL_VERSION="7.*" HORIZON=1
-  - LUMEN_VERSION="5.4.*"
-  - LUMEN_VERSION="5.5.*"
-  - LUMEN_VERSION="5.6.*"
-  - LUMEN_VERSION="5.7.*"
-  - LUMEN_VERSION="5.8.*"
-  - LUMEN_VERSION="6.*"
-  - LUMEN_VERSION="7.*"
+#   - LARAVEL_VERSION="6.*" HORIZON=1
+#   - LARAVEL_VERSION="7.*"
+#   - LARAVEL_VERSION="7.*" HORIZON=1
+#   - LUMEN_VERSION="5.4.*"
+#   - LUMEN_VERSION="5.5.*"
+#   - LUMEN_VERSION="5.6.*"
+#   - LUMEN_VERSION="5.7.*"
+#   - LUMEN_VERSION="5.8.*"
+#   - LUMEN_VERSION="6.*"
+#   - LUMEN_VERSION="7.*"
 
 matrix:
   exclude:
@@ -125,8 +125,9 @@ before_install:
   - if [ -n "$LUMEN_VERSION" ]; then composer remove --dev --no-update "laravel/framework"; fi
   - if [ -n "$LUMEN_VERSION" ]; then composer require --no-update "laravel/lumen-framework:$LUMEN_VERSION"; fi
   - if [ -z "$HORIZON" ]; then composer remove --dev --no-update "laravel/horizon"; fi
-  - phpenv config-rm xdebug.ini
-  - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then printf "\n" | pecl install -f redis; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
 
 install: travis_retry composer install --prefer-dist --no-interaction --no-suggest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,11 +129,11 @@ before_install:
 install: travis_retry composer install --prefer-dist --no-interaction --no-suggest
 
 before_script:
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then printf "yes\n" | pecl install redis; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then printf "yes\n" | pecl install redis; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then printf "yes\n" | pecl install redis; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]]; then printf "yes\n" | pecl install redis; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.4" ]]; then printf "yes\n" | pecl install redis; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then pecl install -f redis; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then pecl install -f redis; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then pecl install -f redis; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]]; then pecl install -f redis; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.4" ]]; then pecl install -f redis; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then echo "extension=redis.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"; fi`
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then echo "extension=redis.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"; fi`
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then echo "extension=redis.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"; fi`

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,20 +125,12 @@ before_install:
   - if [ -n "$LUMEN_VERSION" ]; then composer remove --dev --no-update "laravel/framework"; fi
   - if [ -n "$LUMEN_VERSION" ]; then composer require --no-update "laravel/lumen-framework:$LUMEN_VERSION"; fi
   - if [ -z "$HORIZON" ]; then composer remove --dev --no-update "laravel/horizon"; fi
+  - phpenv config-rm xdebug.ini
+  - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 install: travis_retry composer install --prefer-dist --no-interaction --no-suggest
 
 before_script:
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then pecl install -f redis; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then pecl install -f redis; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then pecl install -f redis; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]]; then pecl install -f redis; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.4" ]]; then pecl install -f redis; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then echo "extension=redis.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"; fi`
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then echo "extension=redis.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"; fi`
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then echo "extension=redis.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"; fi`
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]]; then echo "extension=redis.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"; fi`
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.4" ]]; then echo "extension=redis.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"; fi`
   - SUPERVISE=no travis_retry ./start-cluster.sh || { cat ./cluster/*.log; false; }
 
 script: vendor/bin/phpunit --exclude-group ${LUMEN_VERSION:+laravel-only},${HORIZON:-horizon}

--- a/README.md
+++ b/README.md
@@ -59,9 +59,12 @@ Requirements
 
  - PHP 5.4 or greater
  - [Redis][redis] 2.8 or greater (for Sentinel support)
- - [Predis][predis] 1.1 or greater (for Sentinel client support)
  - [Laravel][laravel] or [Lumen][lumen] 5.0 or greater (4.x doesn't support the
    required Predis version)
+
+Driver options:
+ - [Predis][predis] 1.1 or greater (for Sentinel client support)
+ - [PhpRedis][php-redis] 5.3.4 or greater (for Sentinel client support)
 
 **Note:** Laravel 5.4 introduced the ability to use the [PhpRedis][php-redis]
 extension as a Redis client for the framework. This package does not yet
@@ -132,6 +135,7 @@ QUEUE_CONNECTION=redis-sentinel  # Laravel >= 5.7
 QUEUE_DRIVER=redis-sentinel      # Laravel <= 5.6
 REDIS_DRIVER=redis-sentinel
 
+REDIS_CLIENT=predis
 REDIS_HOST=sentinel1.example.com, sentinel2.example.com, 10.0.0.1, etc.
 REDIS_PORT=26379
 REDIS_SENTINEL_SERVICE=mymaster  # or your Redis master group name
@@ -406,6 +410,30 @@ for a single connection. The default values are shown below:
     // updated set of Sentinels each time the client needs to establish a
     // connection with a Redis master or replica.
     'update_sentinels' => false,
+],
+```
+
+The PhpRedis client supports extra options. The default values are shown below:
+
+```php
+'options' => [
+    ...
+
+    // The default number of attempts to retry the connection if the inititial
+    // connection has failed. A value of 0 instructs the
+    // client to throw an exception after the first failed attempt, while a
+    // value of -1 causes the client to continue to retry commands indefinitely.
+    'connector_retry_limit' => 20,
+
+    // The default amount of time (in milliseconds) that the client waits before
+    // retrying the connection attempt.
+    'connector_retry_wait' => 1000,
+
+    // Sets the persistent option in the RedisSentinel class.
+    'sentinel_persistent' => null,
+
+    // Sets the read timeout option in the RedisSentinel class. 0 means unlimited.
+    'sentinel_read_timeout' => 0,
 ],
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,12 @@
 {
     "name": "monospice/laravel-redis-sentinel-drivers",
     "description": "Redis Sentinel integration for Laravel and Lumen.",
-    "keywords": ["redis", "sentinel", "laravel", "lumen"],
+    "keywords": [
+        "redis",
+        "sentinel",
+        "laravel",
+        "lumen"
+    ],
     "type": "library",
     "license": "MIT",
     "authors": [
@@ -12,21 +17,21 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "illuminate/cache": "^5.4 || ^6.0 || ^7.0 || ^8.0",
-        "illuminate/contracts": "^5.4 || ^6.0 || ^7.0 || ^8.0",
-        "illuminate/queue": "^5.4 || ^6.0 || ^7.0 || ^8.0",
-        "illuminate/redis": "^5.4 || ^6.0 || ^7.0 || ^8.0",
-        "illuminate/session": "^5.4 || ^6.0 || ^7.0 || ^8.0",
-        "illuminate/support": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "illuminate/cache": "^5.4 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "illuminate/contracts": "^5.4 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "illuminate/queue": "^5.4 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "illuminate/redis": "^5.4 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "illuminate/session": "^5.4 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "illuminate/support": "^5.4 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "monospice/spicy-identifiers": "^0.1",
         "predis/predis": "^1.1"
     },
     "require-dev": {
-        "laravel/framework": "^5.4 || ^6.0 || ^7.0 || ^8.0",
-        "laravel/horizon": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-        "laravel/lumen-framework": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "laravel/framework": "^5.4 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "laravel/horizon": "^1.0 || ^2.0 || ^3.0 || ^4.0 || ^5.8",
+        "laravel/lumen-framework": "^5.4 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "mockery/mockery": "^1.3",
-        "phpunit/phpunit": "^5.0"
+        "phpunit/phpunit": "^5.0 || ^9.5.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/Configuration/HostNormalizer.php
+++ b/src/Configuration/HostNormalizer.php
@@ -62,7 +62,7 @@ class HostNormalizer
     public static function normalizeConnections(array $connections)
     {
         foreach ($connections as $name => $connection) {
-            if ($name === 'client' || $name === 'options' || $name === 'clusters') {
+            if (in_array($name, ['client', 'options', 'clusters'])) {
                 continue;
             }
 

--- a/src/Configuration/HostNormalizer.php
+++ b/src/Configuration/HostNormalizer.php
@@ -62,7 +62,7 @@ class HostNormalizer
     public static function normalizeConnections(array $connections)
     {
         foreach ($connections as $name => $connection) {
-            if ($name === 'options' || $name === 'clusters') {
+            if ($name === 'client' || $name === 'options' || $name === 'clusters') {
                 continue;
             }
 

--- a/src/Connections/PhpRedisConnection.php
+++ b/src/Connections/PhpRedisConnection.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Monospice\LaravelRedisSentinel\Connections;
+
+use Illuminate\Redis\Connections\PhpRedisConnection as LaravelPhpRedisConnection;
+use Redis;
+use RedisException;
+
+/**
+ * Executes Redis commands using the PhpRedis client.
+ *
+ * This package extends Laravel's PhpRedisConnection class to work around issues
+ * experienced when using the PhpRedis client to send commands over "aggregate"
+ * connections (in this case, Sentinel connections).
+ *
+ * @category Package
+ * @package  Monospice\LaravelRedisSentinel
+ * @author   @pdbreen, Cy Rossignol <cy@rossignols.me>
+ * @license  See LICENSE file
+ * @link     https://github.com/monospice/laravel-redis-sentinel-drivers
+ */
+class PhpRedisConnection extends LaravelPhpRedisConnection
+{
+    /**
+     * The number of times the client attempts to retry a command when it fails
+     * to connect to a Redis instance behind Sentinel.
+     *
+     * @var int
+     */
+    protected $retryLimit = 20;
+
+    /**
+     * The time in milliseconds to wait before the client retries a failed
+     * command.
+     *
+     * @var int
+     */
+    protected $retryWait = 1000;
+
+    /**
+     * Create a new PhpRedis connection.
+     *
+     * @param  \Redis  $client
+     * @param  callable|null  $connector
+     * @param  array  $sentinelOptions
+     * @return void
+     */
+    public function __construct($client, callable $connector = null, array $sentinelOptions = [])
+    {
+        parent::__construct($client, $connector);
+
+        $this->retryLimit = (int) ($sentinelOptions['retry_limit'] ?? 20);
+        $this->retryWait = (int) ($sentinelOptions['retry_wait'] ?? 1000);
+    }
+
+    /**
+     * Execute commands in a transaction.
+     *
+     * @param  callable|null  $callback
+     * @return \Redis|array
+     */
+    public function transaction(callable $callback = null)
+    {
+        return $this->retryOnFailure(function () use ($callback) {
+            $transaction = $this->client()->multi();
+
+            return is_null($callback)
+                ? $transaction
+                : tap($transaction, $callback)->exec();
+        });
+    }
+    /**
+     * Attempt to retry the provided operation when the client fails to connect
+     * to a Redis server.
+     *
+     * We adapt Predis' Sentinel connection failure handling logic here to
+     * reproduce the high-availability mode provided by the actual client. To
+     * work around "aggregate" connection limitations in Predis, this class
+     * provides methods that don't use the high-level Sentinel connection API
+     * of Predis directly, so it needs to handle connection failures itself.
+     *
+     * @param callable $callback The operation to execute.
+     *
+     * @return mixed The result of the first successful attempt.
+     *
+     * @throws RedisException After exhausting the allowed number of
+     * attempts to reconnect.
+     */
+    protected function retryOnFailure(callable $callback)
+    {
+        $attempts = 0;
+
+        do {
+            try {
+                return $callback();
+            } catch (RedisException $exception) {
+                $this->client->close();
+
+                usleep($this->retryWait * 1000);
+
+                $this->client = $this->connector();
+
+                $attempts++;
+            }
+        } while ($attempts <= $this->retryLimit);
+
+        throw $exception;
+    }
+}

--- a/src/Connections/PhpRedisConnection.php
+++ b/src/Connections/PhpRedisConnection.php
@@ -23,6 +23,15 @@ use RedisException;
 class PhpRedisConnection extends LaravelPhpRedisConnection
 {
     /**
+     * The connection creation callback.
+     *
+     * Laravel 5 does not store the connector by default.
+     *
+     * @var callable
+     */
+    protected $connector;
+
+    /**
      * The number of times the client attempts to retry a command when it fails
      * to connect to a Redis instance behind Sentinel.
      *
@@ -49,6 +58,11 @@ class PhpRedisConnection extends LaravelPhpRedisConnection
     public function __construct($client, callable $connector = null, array $sentinelOptions = [])
     {
         parent::__construct($client, $connector);
+
+        // Set the connector when it is not set. Used for Laravel 5.
+        if (! $this->connector) {
+            $this->connector = $connector;
+        }
 
         $this->retryLimit = (int) (isset($sentinelOptions['retry_limit']) ? $sentinelOptions['retry_limit'] : 20);
         $this->retryWait = (int) (isset($sentinelOptions['retry_wait']) ? $sentinelOptions['retry_wait'] : 1000);

--- a/src/Connections/PhpRedisConnection.php
+++ b/src/Connections/PhpRedisConnection.php
@@ -226,7 +226,7 @@ class PhpRedisConnection extends LaravelPhpRedisConnection
 
                 $attempts++;
             }
-        } while ($attempts < $this->retryLimit);
+        } while ($attempts <= $this->retryLimit);
 
         throw new RedisRetryException(sprintf('Reached the reconnect limit of %d attempts', $attempts));
     }

--- a/src/Connections/PhpRedisConnection.php
+++ b/src/Connections/PhpRedisConnection.php
@@ -2,7 +2,7 @@
 
 namespace Monospice\LaravelRedisSentinel\Connections;
 
-use Monospice\LaravelRedisSentinel\Exceptions\RetryRedisException;
+use Monospice\LaravelRedisSentinel\Exceptions\RedisRetryException;
 use Closure;
 use Illuminate\Redis\Connections\PhpRedisConnection as LaravelPhpRedisConnection;
 use Redis;
@@ -188,7 +188,7 @@ class PhpRedisConnection extends LaravelPhpRedisConnection
      * @param callable $callback The operation to execute.
      * @return mixed The result of the first successful attempt.
      *
-     * @throws RedisException After exhausting the allowed number of
+     * @throws RedisRetryException After exhausting the allowed number of
      * attempts to reconnect.
      */
     protected function retryOnFailure(callable $callback)
@@ -214,6 +214,6 @@ class PhpRedisConnection extends LaravelPhpRedisConnection
             }
         } while ($attempts < $this->retryLimit);
 
-        throw new RetryRedisException(sprintf('Reached the reconnect limit of %d attempts', $attempts));
+        throw new RedisRetryException(sprintf('Reached the reconnect limit of %d attempts', $attempts));
     }
 }

--- a/src/Connections/PhpRedisConnection.php
+++ b/src/Connections/PhpRedisConnection.php
@@ -49,8 +49,8 @@ class PhpRedisConnection extends LaravelPhpRedisConnection
     {
         parent::__construct($client, $connector);
 
-        $this->retryLimit = (int) ($sentinelOptions['retry_limit'] ?? 20);
-        $this->retryWait = (int) ($sentinelOptions['retry_wait'] ?? 1000);
+        $this->retryLimit = (int) (isset($sentinelOptions['retry_limit']) ? $sentinelOptions['retry_limit'] : 20);
+        $this->retryWait = (int) (isset($sentinelOptions['retry_wait']) ? $sentinelOptions['retry_wait'] : 1000);
     }
 
     /**

--- a/src/Connectors/PhpRedisConnector.php
+++ b/src/Connectors/PhpRedisConnector.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Monospice\LaravelRedisSentinel\Connectors;
+
+use Illuminate\Support\Arr;
+use Monospice\LaravelRedisSentinel\Connections\PredisConnection;
+use Illuminate\Redis\Connectors\PhpRedisConnector as LaravelPhpRedisConnector;
+use Monospice\LaravelRedisSentinel\Connections\PhpRedisConnection;
+use RedisSentinel;
+
+/**
+ * Initializes PhpRedis Client instances for Redis Sentinel connections
+ *
+ * @category Package
+ * @package  Monospice\LaravelRedisSentinel
+ * @author   Cy Rossignol <cy@rossignols.me>
+ * @license  See LICENSE file
+ * @link     http://github.com/monospice/laravel-redis-sentinel-drivers
+ */
+class PhpRedisConnector extends LaravelPhpRedisConnector
+{
+    /**
+     * Holds the current sentinel servers.
+     *
+     * @var array
+     */
+    protected $servers = [];
+
+    /**
+     * Configuration options specific to Sentinel connection operation
+     *
+     * We cannot pass these options as an array to the Predis client.
+     * Instead, we'll set them on the connection directly using methods
+     * provided by the SentinelReplication class of the Predis package.
+     *
+     * @var array
+     */
+    protected $sentinelKeys = [
+        'sentinel_timeout' => null,
+        'retry_wait' => null,
+        'retry_limit' => null,
+        'update_sentinels' => null,
+
+        'sentinel_persistent' => null,
+        'sentinel_read_timeout' => null,
+    ];
+
+    /**
+     * Create a new Redis Sentinel connection from the provided configuration
+     * options
+     *
+     * @param array $server  The client configuration for the connection
+     * @param array $options The global client options shared by all Sentinel
+     * connections
+     *
+     * @return PredisConnection The Sentinel connection containing a configured
+     * Predis Client
+     */
+    public function connect(array $servers, array $options = [ ])
+    {
+        // Merge the global options shared by all Sentinel connections with
+        // connection-specific options
+        $clientOpts = array_merge($options, Arr::pull($servers, 'options', [ ]));
+
+        // Extract the array of Sentinel connection options from the rest of
+        // the client options
+        $sentinelOpts = array_intersect_key($clientOpts, $this->sentinelKeys);
+
+        // Filter the Sentinel connection options elements from the client
+        // options array
+        $clientOpts = array_diff_key($clientOpts, $this->sentinelKeys);
+
+        // Create a client by calling the Sentinel servers
+        $connector = function () use ($servers, $options) {
+            return $this->createClientWithSentinel($servers, $options);
+        };
+
+        return new PhpRedisConnection($connector(), $connector, $sentinelOpts);
+    }
+
+    /**
+     * Create the Redis client instance.
+     *
+     * @param  array  $servers
+     * @param  array  $options
+     * @return \Redis
+     */
+    protected function createClientWithSentinel(array $servers, array $options)
+    {
+        shuffle($servers);
+
+        foreach ($servers as $server) {
+            $sentinel = new RedisSentinel(
+                $server['host'] ?? 'localhost',
+                $server['port'] ?? 26739,
+                $options['sentinel_timeout'] ?? 0,
+                $options['sentinel_persistent'] ?? null,
+                $options['retry_wait'] ?? 0,
+                $options['sentinel_read_timeout'] ?? 0,
+            );
+
+            // @TODO update_sentinels
+            // $this->servers = $sentinel->sentinels($options['service'] ?? 'mymaster');
+            // var_dump($sentinel->sentinels($options['service'] ?? 'mymaster'));
+            // var_dump($sentinel->masters());
+
+            $master = $sentinel->getMasterAddrByName($options['service'] ?? 'mymaster');
+            if ($master !== false) {
+                $config['host'] = $master[0];
+                $config['port'] = $master[1];
+
+                var_dump($config);
+
+                return $this->createClient($config);
+            }
+        }
+    }
+}

--- a/src/Connectors/PhpRedisConnector.php
+++ b/src/Connectors/PhpRedisConnector.php
@@ -154,10 +154,12 @@ class PhpRedisConnector extends LaravelPhpRedisConnector
                     'host' => $currentHost,
                     'port' => $currentPort,
                 ]
-            ], array_map(fn ($sentinel) => [
-                'host' => $sentinel['ip'],
-                'port' => $sentinel['port'],
-            ], $sentinel->sentinels($service))
+            ], array_map(function ($sentinel) {
+                return [
+                    'host' => $sentinel['ip'],
+                    'port' => $sentinel['port'],
+                ];
+            }, $sentinel->sentinels($service))
         );
     }
 

--- a/src/Exceptions/RedisRetryException.php
+++ b/src/Exceptions/RedisRetryException.php
@@ -4,7 +4,7 @@ namespace Monospice\LaravelRedisSentinel\Exceptions;
 
 use RedisException as PhpRedisException;
 
-class RetryRedisException extends PhpRedisException
+class RedisRetryException extends PhpRedisException
 {
     //
 }

--- a/src/Exceptions/RetryRedisException.php
+++ b/src/Exceptions/RetryRedisException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Monospice\LaravelRedisSentinel\Exceptions;
+
+use RedisException as PhpRedisException;
+
+class RetryRedisException extends PhpRedisException
+{
+    //
+}

--- a/src/Manager/VersionedRedisSentinelManager.php
+++ b/src/Manager/VersionedRedisSentinelManager.php
@@ -70,6 +70,8 @@ abstract class VersionedRedisSentinelManager
         switch ($this->driver) {
             case 'predis':
                 return new Connectors\PredisConnector();
+            case 'phpredis':
+                return new Connectors\PhpRedisConnector();
         }
 
         throw new InvalidArgumentException(

--- a/tests/Integration/Connections/PhpRedisConnectionTest.php
+++ b/tests/Integration/Connections/PhpRedisConnectionTest.php
@@ -29,7 +29,7 @@ class PhpRedisConnectionTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->subject = $this->makeClient();
+        $this->subject = $this->makeConnection();
     }
 
     /**
@@ -99,7 +99,7 @@ class PhpRedisConnectionTest extends IntegrationTestCase
 
         $expectedRetries = 2;
 
-        $this->subject = $this->makeClient($expectedRetries, 0); // retry immediately
+        $this->subject = $this->makeConnection($expectedRetries, 0); // retry immediately
 
         $this->subject->transaction(function () {
             throw new RedisException();
@@ -111,7 +111,7 @@ class PhpRedisConnectionTest extends IntegrationTestCase
         $retries = 3;
         $attempts = 0;
 
-        $this->subject = $this->makeClient($retries, 0); // retry immediately
+        $this->subject = $this->makeConnection($retries, 0); // retry immediately
 
         $this->subject->transaction(function ($trans) use (&$attempts, $retries) {
             $attempts++;
@@ -133,9 +133,9 @@ class PhpRedisConnectionTest extends IntegrationTestCase
      *
      * @param int|null $retryLimit
      * @param int|null $retryWait
-     * @return Redis A client instance for the subject under test.
+     * @return PhpRedisConnection A client instance for the subject under test.
      */
-    protected function makeClient(int $retryLimit = null, int $retryWait = null)
+    protected function makeConnection(int $retryLimit = null, int $retryWait = null)
     {
         $connector = new PhpRedisConnector();
 

--- a/tests/Integration/Connections/PhpRedisConnectionTest.php
+++ b/tests/Integration/Connections/PhpRedisConnectionTest.php
@@ -2,7 +2,6 @@
 
 namespace Monospice\LaravelRedisSentinel\Tests\Integration\Connections;
 
-use Mockery;
 use Monospice\LaravelRedisSentinel\Connections\PhpRedisConnection;
 use Monospice\LaravelRedisSentinel\Connectors\PhpRedisConnector;
 use Monospice\LaravelRedisSentinel\Tests\Support\DummyException;
@@ -29,19 +28,13 @@ class PhpRedisConnectionTest extends IntegrationTestCase
     {
         parent::setUp();
 
+        if (! extension_loaded('redis')) {
+            $this->markTestSkipped('The redis extension is not installed. Please install the extension to enable '.__CLASS__);
+
+            return;
+        }
+
         $this->subject = $this->makeConnection();
-    }
-
-    /**
-     * Run this cleanup after each test.
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        parent::tearDown();
-
-        Mockery::close();
     }
 
     public function testAllowsTransactionsOnAggregateConnection()

--- a/tests/Integration/Connections/PhpRedisConnectionTest.php
+++ b/tests/Integration/Connections/PhpRedisConnectionTest.php
@@ -7,7 +7,7 @@ use Monospice\LaravelRedisSentinel\Connections\PhpRedisConnection;
 use Monospice\LaravelRedisSentinel\Connectors\PhpRedisConnector;
 use Monospice\LaravelRedisSentinel\Tests\Support\DummyException;
 use Monospice\LaravelRedisSentinel\Tests\Support\IntegrationTestCase;
-use Monospice\LaravelRedisSentinel\Exceptions\RetryRedisException;
+use Monospice\LaravelRedisSentinel\Exceptions\RedisRetryException;
 use Redis;
 use RedisException;
 
@@ -95,11 +95,9 @@ class PhpRedisConnectionTest extends IntegrationTestCase
 
     public function testRetriesTransactionWhenConnectionFails()
     {
-        $this->expectException(RetryRedisException::class);
+        $this->expectException(RedisRetryException::class);
 
-        $expectedRetries = 2;
-
-        $this->subject = $this->makeConnection($expectedRetries, 0); // retry immediately
+        $this->subject = $this->makeConnection(1, 0); // retry once and immediately
 
         $this->subject->transaction(function () {
             throw new RedisException();

--- a/tests/Integration/Connections/PhpRedisConnectionTest.php
+++ b/tests/Integration/Connections/PhpRedisConnectionTest.php
@@ -29,8 +29,6 @@ class PhpRedisConnectionTest extends IntegrationTestCase
         parent::setUp();
 
         if (! extension_loaded('redis')) {
-            $this->markTestSkipped('The redis extension is not installed. Please install the extension to enable '.__CLASS__);
-
             return;
         }
 
@@ -39,6 +37,12 @@ class PhpRedisConnectionTest extends IntegrationTestCase
 
     public function testAllowsTransactionsOnAggregateConnection()
     {
+        if (! extension_loaded('redis')) {
+            $this->markTestSkipped('The redis extension is not installed. Please install the extension to enable '.__CLASS__);
+
+            return;
+        }
+
         $transaction = $this->subject->transaction();
 
         $this->assertInstanceOf(Redis::class, $transaction);
@@ -46,6 +50,12 @@ class PhpRedisConnectionTest extends IntegrationTestCase
 
     public function testExecutesCommandsInTransaction()
     {
+        if (! extension_loaded('redis')) {
+            $this->markTestSkipped('The redis extension is not installed. Please install the extension to enable '.__CLASS__);
+
+            return;
+        }
+
         $result = $this->subject->transaction(function ($trans) {
             $trans->set('test-key', 'test value');
             $trans->get('test-key');
@@ -59,6 +69,12 @@ class PhpRedisConnectionTest extends IntegrationTestCase
 
     public function testExecutesTransactionsOnMaster()
     {
+        if (! extension_loaded('redis')) {
+            $this->markTestSkipped('The redis extension is not installed. Please install the extension to enable '.__CLASS__);
+
+            return;
+        }
+
         $expectedSubset = ['role' => 'master'];
 
         $info = $this->subject->transaction(function ($transaction) {
@@ -70,6 +86,12 @@ class PhpRedisConnectionTest extends IntegrationTestCase
 
     public function testAbortsTransactionOnException()
     {
+        if (! extension_loaded('redis')) {
+            $this->markTestSkipped('The redis extension is not installed. Please install the extension to enable '.__CLASS__);
+
+            return;
+        }
+
         $exception = null;
 
         try {
@@ -88,6 +110,12 @@ class PhpRedisConnectionTest extends IntegrationTestCase
 
     public function testRetriesTransactionWhenConnectionFails()
     {
+        if (! extension_loaded('redis')) {
+            $this->markTestSkipped('The redis extension is not installed. Please install the extension to enable '.__CLASS__);
+
+            return;
+        }
+
         $this->expectException(RedisRetryException::class);
 
         $this->subject = $this->makeConnection(1, 0); // retry once and immediately
@@ -99,6 +127,12 @@ class PhpRedisConnectionTest extends IntegrationTestCase
 
     public function testCanReconnectWhenConnectionFails()
     {
+        if (! extension_loaded('redis')) {
+            $this->markTestSkipped('The redis extension is not installed. Please install the extension to enable '.__CLASS__);
+
+            return;
+        }
+
         $retries = 3;
         $attempts = 0;
 

--- a/tests/Integration/Connections/PhpRedisConnectionTest.php
+++ b/tests/Integration/Connections/PhpRedisConnectionTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Monospice\LaravelRedisSentinel\Tests\Integration\Connections;
+
+use Mockery;
+use Monospice\LaravelRedisSentinel\Connections\PhpRedisConnection;
+use Monospice\LaravelRedisSentinel\Connectors\PhpRedisConnector;
+use Monospice\LaravelRedisSentinel\Tests\Support\DummyException;
+use Monospice\LaravelRedisSentinel\Tests\Support\IntegrationTestCase;
+use Monospice\LaravelRedisSentinel\Exceptions\RetryRedisException;
+use Redis;
+use RedisException;
+
+class PhpRedisConnectionTest extends IntegrationTestCase
+{
+    /**
+     * The instance of the PhpRedis client wrapper under test.
+     *
+     * @var PhpRedisConnection
+     */
+    protected $subject;
+
+    /**
+     * Run this setup before each test
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->subject = $this->makeClient();
+    }
+
+    /**
+     * Run this cleanup after each test.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        Mockery::close();
+    }
+
+    public function testAllowsTransactionsOnAggregateConnection()
+    {
+        $transaction = $this->subject->transaction();
+
+        $this->assertInstanceOf(Redis::class, $transaction);
+    }
+
+    public function testExecutesCommandsInTransaction()
+    {
+        $result = $this->subject->transaction(function ($trans) {
+            $trans->set('test-key', 'test value');
+            $trans->get('test-key');
+        });
+
+        $this->assertCount(2, $result);
+        $this->assertTrue($result[0]);
+        $this->assertEquals('test value', $result[1]);
+        $this->assertRedisKeyEquals('test-key', 'test value');
+    }
+
+    public function testExecutesTransactionsOnMaster()
+    {
+        $expectedSubset = ['role' => 'master'];
+
+        $info = $this->subject->transaction(function ($transaction) {
+            $transaction->info();
+        });
+
+        $this->assertArraySubset($expectedSubset, $info[0]);
+    }
+
+    public function testAbortsTransactionOnException()
+    {
+        $exception = null;
+
+        try {
+            $this->subject->transaction(function ($trans) {
+                $trans->set('test-key', 'test value');
+                throw new DummyException();
+            });
+        } catch (DummyException $exception) {
+            // With PHPUnit, we need to wrap the throwing block to perform
+            // assertions afterward.
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertRedisKeyEquals('test-key', null);
+    }
+
+    public function testRetriesTransactionWhenConnectionFails()
+    {
+        $this->expectException(RetryRedisException::class);
+
+        $expectedRetries = 2;
+
+        $this->subject = $this->makeClient($expectedRetries, 0); // retry immediately
+
+        $this->subject->transaction(function () {
+            throw new RedisException();
+        });
+    }
+
+    public function testCanReconnectWhenConnectionFails()
+    {
+        $retries = 3;
+        $attempts = 0;
+
+        $this->subject = $this->makeClient($retries, 0); // retry immediately
+
+        $this->subject->transaction(function ($trans) use (&$attempts, $retries) {
+            $attempts++;
+
+            if ($attempts < $retries) {
+                throw new RedisException();
+            } else {
+                $trans->set('test-key', 'test value');
+            }
+        });
+
+        $this->assertGreaterThan(1, $attempts, 'First try does not count.');
+        $this->assertRedisKeyEquals('test-key', 'test value');
+    }
+
+    /**
+     * Initialize a PhpRedis client using the test connection configuration
+     * that can verify connectivity failure handling.
+     *
+     * @param int|null $retryLimit
+     * @param int|null $retryWait
+     * @return Redis A client instance for the subject under test.
+     */
+    protected function makeClient(int $retryLimit = null, int $retryWait = null)
+    {
+        $connector = new PhpRedisConnector();
+
+        $options = $this->config['options'];
+        if ($retryLimit !== null) {
+            $options['retry_limit'] = $retryLimit;
+        }
+
+        if ($retryWait !== null) {
+            $options['retry_wait'] = $retryWait;
+        }
+
+        return $connector->connect($this->config['default'], $options);
+    }
+}

--- a/tests/Integration/Connectors/PhpRedisConnectorTest.php
+++ b/tests/Integration/Connectors/PhpRedisConnectorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Monospice\LaravelRedisSentinel\Tests\Integration\Connections;
+
+use Monospice\LaravelRedisSentinel\Connections\PhpRedisConnection;
+use Monospice\LaravelRedisSentinel\Connectors\PhpRedisConnector;
+use Monospice\LaravelRedisSentinel\Tests\Support\IntegrationTestCase;
+use Monospice\LaravelRedisSentinel\Exceptions\RedisRetryException;
+
+class PhpRedisConnectorTest extends IntegrationTestCase
+{
+    /**
+     * Run this setup before each test
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        if (! extension_loaded('redis')) {
+            return;
+        }
+    }
+
+    public function testCanConnect()
+    {
+        if (! extension_loaded('redis')) {
+            $this->markTestSkipped('The redis extension is not installed. Please install the extension to enable '.__CLASS__);
+
+            return;
+        }
+
+        $connector = new PhpRedisConnector();
+        $client = $connector->connect($this->config['default'], $this->config['options']);
+
+        $this->assertInstanceOf(PhpRedisConnection::class, $client);
+    }
+
+    public function testRetriesTransactionWhenConnectionFails()
+    {
+        if (! extension_loaded('redis')) {
+            $this->markTestSkipped('The redis extension is not installed. Please install the extension to enable '.__CLASS__);
+
+            return;
+        }
+
+        $this->expectException(RedisRetryException::class);
+
+        $connector = new PhpRedisConnector();
+
+        $servers = [
+            [
+                'host' => '127.0.0.1',
+                'port' => 1111,
+            ],
+        ];
+
+        $options = array_merge([
+            'connector_retry_limit' => 3,
+            'connector_retry_wait' => 0,
+        ]);
+
+        $connector = new PhpRedisConnector();
+        $connector->connect($servers, $options);
+    }
+}

--- a/tests/Unit/Configuration/LoaderTest.php
+++ b/tests/Unit/Configuration/LoaderTest.php
@@ -499,9 +499,9 @@ class LoaderTest extends TestCase
 
     public function testDisallowsUsingNonexistantConnectionForHorizon()
     {
-        $this->config->set('horizon.use', 'not-a-connection');
+        $this->expectException(UnexpectedValueException::class);
 
-        $this->setExpectedException(UnexpectedValueException::class);
+        $this->config->set('horizon.use', 'not-a-connection');
 
         $this->loader->loadHorizonConfiguration();
     }

--- a/tests/Unit/Connections/PredisConnectionTest.php
+++ b/tests/Unit/Connections/PredisConnectionTest.php
@@ -102,7 +102,7 @@ class PredisConnectionTest extends TestCase
 
     public function testDisallowsInvalidSentinelOptions()
     {
-        $this->setExpectedException(BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
 
         new PredisConnection($this->clientMock, [ 'not_an_option' => null  ]);
     }

--- a/tests/Unit/Manager/VersionedRedisSentinelManagerTest.php
+++ b/tests/Unit/Manager/VersionedRedisSentinelManagerTest.php
@@ -2,7 +2,6 @@
 
 namespace Monospice\LaravelRedisSentinel\Tests\Unit;
 
-use Closure;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Illuminate\Redis\RedisManager;
@@ -118,23 +117,23 @@ class VersionedRedisSentinelManagerTest extends TestCase
 
     public function testDisallowsRedisClusterConnections()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $this->subject->connection('clustered_connection');
     }
 
     public function testFailsOnUndefinedConnection()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $this->subject->connection('nonexistant_connection');
     }
 
     public function testFailsOnUnsupportedClientDriver()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
-        $manager = $this->makeSubject('phpredis', [
+        $manager = $this->makeSubject('fakeredis', [
             'test_connection' => [ ],
         ]);
 

--- a/tests/Unit/RedisSentinelServiceProviderTest.php
+++ b/tests/Unit/RedisSentinelServiceProviderTest.php
@@ -200,10 +200,11 @@ class RedisSentinelServiceProviderTest extends TestCase
 
     public function testWaitsForBoot()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->app->config->set('redis-sentinel.auto_boot', false);
         $this->provider->register();
 
-        $this->setExpectedException(\InvalidArgumentException::class);
 
         // It didn't auto boot
         $this->assertNull($this->app->cache->store('redis-sentinel'));


### PR DESCRIPTION
This PR implements the PhpRedis client for Redis Sentinel. It wraps all methods with a retryOnFailure and creates a new Redis client when the connection fails.